### PR TITLE
fix: pagination

### DIFF
--- a/packages/sunflower-antd-form-table/src/index.tsx
+++ b/packages/sunflower-antd-form-table/src/index.tsx
@@ -170,6 +170,11 @@ export const useFormTable = (config: UseSearchResultAntdConfig) => {
     pagination: {
       onChange: onPaginationChange,
       onShowSizeChange: onPaginationShowSizeChange,
+      pageSize: requestData.pageSize,
+      current: requestData.currentPage,
+      total: responseData.total,
+      defaultPageSize,
+      defaultCurrent: defaultCurrentPage,
     },
     onFinish,
     // requestData,


### PR DESCRIPTION
处理不用table模式使用分页时，重新搜索currentPage不重置问题，并返回default值，使其可配置。